### PR TITLE
SimpleWebRTC - adding Vulkan support

### DIFF
--- a/DecartAI-Quest-Unity/LocalPackages/com.firedragongamestudio.simplewebrtc/package.json
+++ b/DecartAI-Quest-Unity/LocalPackages/com.firedragongamestudio.simplewebrtc/package.json
@@ -6,7 +6,7 @@
   "unityRelease": "0f1",
   "description": "Unity-based WebRTC wrapper that facilitates peer-to-peer audio, video, and data communication over WebRTC.",
   "dependencies": {
-    "com.unity.webrtc": "3.0.0-pre.8",
+    "com.unity.webrtc": "3.0.0",
     "com.unity.textmeshpro": "3.0.6"
   },
   "keywords": [

--- a/DecartAI-Quest-Unity/Packages/packages-lock.json
+++ b/DecartAI-Quest-Unity/Packages/packages-lock.json
@@ -11,7 +11,7 @@
       "depth": 0,
       "source": "local",
       "dependencies": {
-        "com.unity.webrtc": "3.0.0-pre.8",
+        "com.unity.webrtc": "3.0.0",
         "com.unity.textmeshpro": "3.0.6"
       }
     },
@@ -245,7 +245,7 @@
       }
     },
     "com.unity.webrtc": {
-      "version": "3.0.0-pre.8",
+      "version": "3.0.0",
       "depth": 1,
       "source": "registry",
       "dependencies": {

--- a/DecartAI-Quest-Unity/ProjectSettings/ProjectSettings.asset
+++ b/DecartAI-Quest-Unity/ProjectSettings/ProjectSettings.asset
@@ -178,7 +178,7 @@ PlayerSettings:
   overrideDefaultApplicationIdentifier: 1
   AndroidBundleVersionCode: 1
   AndroidMinSdkVersion: 32
-  AndroidTargetSdkVersion: 0
+  AndroidTargetSdkVersion: 32
   AndroidPreferredInstallLocation: 0
   aotOptions: 
   stripEngineCode: 1
@@ -547,7 +547,7 @@ PlayerSettings:
     m_APIs: 10000000
     m_Automatic: 1
   - m_BuildTarget: AndroidPlayer
-    m_APIs: 0b000000
+    m_APIs: 15000000
     m_Automatic: 0
   m_BuildTargetVRSettings: []
   m_DefaultShaderChunkSizeInMB: 16

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Navigate to **Edit → Project Settings → XR Plug-in Management → Oculus**:
 Navigate to **Edit → Project Settings → Player → Android Settings**:
 
 #### Graphics Settings
-- **Graphics APIs**: **OpenGLES3** only (remove Vulkan if present)
+- **Graphics APIs**: **Vulkan** or **OpenGLES3**
 - **Color Space**: Linear
 - **Rendering Path**: Forward
 


### PR DESCRIPTION
- Updated local package SimpleWebRTC dependency to include Unity WebRTC 3.0.0 to support Vulkan on Quest (tested successfully on my Quest3 with builds done on Unity 6000.0.34f1 and Unity 6000.2.6f2) 
- Adapted readme, to reflect changes (either use Vulkan or OpenGLES 3)
- Updated project settings, to automatically target Vulkan as graphics API (removed OpenGLES 3 from list)