### PR TITLE
Remove vestigial com.unity.textmeshpro dependency from vendored SimpleWebRTC

### DIFF
--- a/DecartAI-Quest-Unity/LocalPackages/com.firedragongamestudio.simplewebrtc/package.json
+++ b/DecartAI-Quest-Unity/LocalPackages/com.firedragongamestudio.simplewebrtc/package.json
@@ -6,8 +6,7 @@
   "unityRelease": "0f1",
   "description": "Unity-based WebRTC wrapper that facilitates peer-to-peer audio, video, and data communication over WebRTC.",
   "dependencies": {
-    "com.unity.webrtc": "3.0.0",
-    "com.unity.textmeshpro": "3.0.6"
+    "com.unity.webrtc": "3.0.0"
   },
   "keywords": [
     "Audio",


### PR DESCRIPTION
## Why

Wiz flags this repo with a HIGH "Repository with malicious library or package" issue (OSSF **MAL-2022-2105**) because the vendored SimpleWebRTC package declares `com.unity.textmeshpro: 3.0.6` in its `package.json`, and an npm squatter package once used that name.

This is a false positive — the file is a Unity UPM manifest, not npm — but the dependency is also genuinely vestigial:

- The project runs Unity 6 with `com.unity.ugui: 2.0.0` in `Packages/manifest.json`, and **TextMeshPro was merged into uGUI 2.0** — the standalone package no longer exists for this Unity version.
- The pinned `3.0.6` target doesn't resolve in Unity 6 anyway.
- The malicious npm package was removed from the registry in Sep 2021 (security-holder tombstone), and version 3.0.6 never existed on npm — so `npm install` could never have fetched it.

## What

One line removed from `DecartAI-Quest-Unity/LocalPackages/com.firedragongamestudio.simplewebrtc/package.json`. The real `com.unity.webrtc` dependency is untouched. No functional change — TMP already arrives via uGUI 2.0.

Removing the line clears the Wiz issue at the source on the next code scan, with no scanner ignore-rules needed. Upstream SimpleWebRTC 1.6.0 still carries the line, so re-vendoring later will need the same one-line edit.

https://claude.ai/code/session_017aZx55zVfoqYB2xk82CffS